### PR TITLE
[Bug] Fix LinesTrimLeft/Right when handle unicode strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,15 @@ line-2 abc xyz
 }
 ```
 
+#### LinesTrim/LinesTrimSpace
+
+Removes all certain leading and trailing characters from every line in the given string.
+
+```go
+LinesTrimSpace("  line-1  \n  line-2  ")      // "line-1\nline-2"
+LinesTrim("a line-1 b \n a line-2 ab", " ba") // "line-1\nline2"
+```
+
 #### LinesTrimLeft/LinesTrimLeftSpace
 
 Removes all certain leading characters from every line in the given string.
@@ -603,15 +612,6 @@ Removes all certain trailing characters from every line in the given string.
 ```go
 LinesTrimRightSpace("  line-1  \n  line-2  ")    // "  line-1\nline-2"
 LinesTrimRight("line-1 b \n a line-2 ab", " ba") // "line-1\n a line2"
-```
-
-#### LinesTrim/LinesTrimSpace
-
-Removes all certain leading and trailing characters from every line in the given string.
-
-```go
-LinesTrimSpace("  line-1  \n  line-2  ")      // "line-1\nline-2"
-LinesTrim("a line-1 b \n a line-2 ab", " ba") // "line-1\nline2"
 ```
 
 ### Common functions

--- a/string_test.go
+++ b/string_test.go
@@ -38,6 +38,7 @@ func Test_RandStringEx(t *testing.T) {
 }
 
 func Test_LinesTrimLeft(t *testing.T) {
+	assert.Equal(t, "", LinesTrimLeftSpace(""))
 	assert.Equal(t, "line-1\nline-2", LinesTrimLeftSpace(`line-1
 		line-2`))
 	assert.Equal(t, "\nline-1\nline-2", LinesTrimLeftSpace(`
@@ -55,12 +56,16 @@ func Test_LinesTrimLeft(t *testing.T) {
 		  â  line-1
 		line-2 â`))
 	// Extra func test
+	assert.Equal(t, "\nê b â  line-1\nê line-2 â ê ", LinesTrimLeft(`
+		 a ê b â  line-1
+		  b aê line-2 â ê `, "a b\t")) // ascii cutset
 	assert.Equal(t, "\nâ  line-1\nline-2 â ê", LinesTrimLeft(`
 		 ê â  line-1
-		 ê line-2 â ê`, string([]rune{' ', '\t', 'ê'})))
+		 ê line-2 â ê`, "a b\tê")) // unicode cutset
 }
 
 func Test_LinesTrimRight(t *testing.T) {
+	assert.Equal(t, "", LinesTrimRightSpace(""))
 	assert.Equal(t, "line-1\nline-2", LinesTrimRightSpace(`line-1
 line-2`))
 	assert.Equal(t, "\nline-1\nline-2\n", LinesTrimRightSpace(`
@@ -79,12 +84,16 @@ line-2`))
 â  line-1  â  
 line-2`))
 	// Extra func test
-	assert.Equal(t, "\nâ  line-1  â\nline-2", LinesTrimRight(`
+	assert.Equal(t, "\nâ  line-1  â  ê\nline-2  ê", LinesTrimRight(`
 â  line-1  â  ê  
-line-2  ê  `, string([]rune{' ', '\t', 'ê'})))
+line-2  ê  `, "a b\t")) // ascii cutset
+	assert.Equal(t, "\n â  line-1  â\nline-2", LinesTrimRight(`
+ â  line-1  â  ê  
+line-2  ê  `, "a b\tê")) // unicode cutset
 }
 
 func Test_LinesTrim(t *testing.T) {
+	assert.Equal(t, "", LinesTrimSpace(""))
 	assert.Equal(t, "line-1\nline-2", LinesTrimSpace(`line-1
 line-2`))
 	assert.Equal(t, "\nline-1\nline-2\n", LinesTrimSpace(`
@@ -105,5 +114,5 @@ line-1
 	// Extra func test
 	assert.Equal(t, "\nâ  line-1  â\nline-2", LinesTrim(`
     â  line-1  â  ê  
-    line-2  ê  `, string([]rune{' ', '\t', 'ê'})))
+    line-2  ê  `, "a b\tê"))
 }


### PR DESCRIPTION
When input unicode strings, the processing produces invalid output.