### PR TITLE
Refactor: rename MapOmit to MapOmitCopy

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,12 +455,12 @@ Copies map content for specified keys only.
 MapPick(map[int]int{1: 11, 2: 22, 3: 33}, 2, 3, 2) // map[int]int{2: 22, 3: 33}
 ```
 
-#### MapOmit
+#### MapOmitCopy
 
 Copies map content with omitting specified keys.
 
 ```go
-MapOmit(map[int]int{1: 11, 2: 22, 3: 33}, 2, 3, 4) // map[int]int{1: 11}
+MapOmitCopy(map[int]int{1: 11, 2: 22, 3: 33}, 2, 3, 4) // map[int]int{1: 11}
 ```
 
 ### Functions for structs

--- a/map.go
+++ b/map.go
@@ -210,8 +210,8 @@ func MapPick[K comparable, V any, M ~map[K]V](m M, keys ...K) M {
 	return ret
 }
 
-// MapOmit returns a new map with omitting the specified keys
-func MapOmit[K comparable, V any, M ~map[K]V](m M, keys ...K) M {
+// MapOmitCopy returns a new map with omitting the specified keys
+func MapOmitCopy[K comparable, V any, M ~map[K]V](m M, keys ...K) M {
 	omitKeys := MapSliceToMapKeys(keys, struct{}{})
 
 	// Copy only keys not in the list
@@ -227,6 +227,6 @@ func MapOmit[K comparable, V any, M ~map[K]V](m M, keys ...K) M {
 
 // MapCopyExcludeKeys returns a new map with omitting the specified keys.
 // Deprecated: Use MapOmit instead.
-func MapCopyExcludeKeys[K comparable, V any, M ~map[K]V](m M, excludedKeys ...K) M {
-	return MapOmit(m, excludedKeys...)
+func MapCopyExcludeKeys[K comparable, V any, M ~map[K]V](m M, keys ...K) M {
+	return MapOmitCopy(m, keys...)
 }

--- a/map_test.go
+++ b/map_test.go
@@ -250,13 +250,13 @@ func Test_MapPick(t *testing.T) {
 	assert.True(t, MapEqual(map[int]int{2: 22}, MapPick(map[int]int{1: 11, 2: 22}, 2, 3, 2)))
 }
 
-func Test_MapOmit(t *testing.T) {
+func Test_MapOmitCopy(t *testing.T) {
 	// Nil/empty maps
-	assert.Equal(t, map[int]int{}, MapOmit[int, int, map[int]int](nil))
-	assert.Equal(t, map[int]int{}, MapOmit[int, int](map[int]int{}, 1, 2, 3))
+	assert.Equal(t, map[int]int{}, MapOmitCopy[int, int, map[int]int](nil))
+	assert.Equal(t, map[int]int{}, MapOmitCopy[int, int](map[int]int{}, 1, 2, 3))
 
-	assert.True(t, MapEqual(map[int]int{1: 11, 2: 22}, MapOmit(map[int]int{1: 11, 2: 22})))
-	assert.True(t, MapEqual(map[int]int{1: 11}, MapOmit(map[int]int{1: 11, 2: 22}, 2, 3, 2)))
+	assert.True(t, MapEqual(map[int]int{1: 11, 2: 22}, MapOmitCopy(map[int]int{1: 11, 2: 22})))
+	assert.True(t, MapEqual(map[int]int{1: 11}, MapOmitCopy(map[int]int{1: 11, 2: 22}, 2, 3, 2)))
 }
 
 func Test_MapCopyExcludeKeys(t *testing.T) {


### PR DESCRIPTION
## Why

- MapOmit returns a new map, we plan to use MapOmit to modifying the current map. So rename this to MapOmitCopy.