### PR TITLE
Refactor type names

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -19,7 +19,7 @@ func ToStringSlice[U, T ~string, S ~[]T](slice S) []U {
 }
 
 // ToNumberSlice converts int-approximate slice to int slice
-func ToNumberSlice[U, T NumberEx, S ~[]T](slice S) []U {
+func ToNumberSlice[U, T NumberExt, S ~[]T](slice S) []U {
 	result := make([]U, len(slice))
 	for i := range slice {
 		result[i] = U(slice[i])

--- a/filter.go
+++ b/filter.go
@@ -29,22 +29,22 @@ func FilterPtr[T any, S ~[]T](s S, filterFunc func(t *T) bool) S {
 }
 
 // FilterLT returns all values which are less than the specified value
-func FilterLT[T NumberEx | StringEx, S ~[]T](s S, v T) S {
+func FilterLT[T NumberExt | StringExt, S ~[]T](s S, v T) S {
 	return Filter(s, func(t T) bool { return t < v })
 }
 
 // FilterLTE returns all values which are less than or equal to the specified value
-func FilterLTE[T NumberEx | StringEx, S ~[]T](s S, v T) S {
+func FilterLTE[T NumberExt | StringExt, S ~[]T](s S, v T) S {
 	return Filter(s, func(t T) bool { return t <= v })
 }
 
 // FilterGT returns all values which are greater than the specified value
-func FilterGT[T NumberEx | StringEx, S ~[]T](s S, v T) S {
+func FilterGT[T NumberExt | StringExt, S ~[]T](s S, v T) S {
 	return Filter(s, func(t T) bool { return t > v })
 }
 
 // FilterGTE returns all values which are greater than or equal to the specified value
-func FilterGTE[T NumberEx | StringEx, S ~[]T](s S, v T) S {
+func FilterGTE[T NumberExt | StringExt, S ~[]T](s S, v T) S {
 	return Filter(s, func(t T) bool { return t >= v })
 }
 
@@ -80,7 +80,7 @@ func FilterNIN[T comparable, S ~[]T](s S, v ...T) S {
 // FilterLIKE returns all strings which contain the specified substring.
 // Don't use wildcard in the input string.
 // For example: FilterLIKE(names, "tom").
-func FilterLIKE[T StringEx, S ~[]T](s S, v string) S {
+func FilterLIKE[T StringExt, S ~[]T](s S, v string) S {
 	if len(v) == 0 {
 		return S{}
 	}
@@ -90,7 +90,7 @@ func FilterLIKE[T StringEx, S ~[]T](s S, v string) S {
 }
 
 // FilterILIKE returns all strings which contain the specified substring with case-insensitive
-func FilterILIKE[T StringEx, S ~[]T](s S, v string) S {
+func FilterILIKE[T StringExt, S ~[]T](s S, v string) S {
 	if len(v) == 0 {
 		return S{}
 	}

--- a/min_max.go
+++ b/min_max.go
@@ -1,7 +1,7 @@
 package gofn
 
 // Min find the minimum value in the list
-func Min[T NumberEx | ~string](v1 T, s ...T) T {
+func Min[T NumberExt | StringExt](v1 T, s ...T) T {
 	min := v1
 	for i := range s {
 		if s[i] < min {
@@ -13,7 +13,7 @@ func Min[T NumberEx | ~string](v1 T, s ...T) T {
 
 // MinIn find the minimum value in the list.
 // Use min := Must(MinIn(slice)) to panic on error.
-func MinIn[T NumberEx | ~string, S ~[]T](s S) (T, error) {
+func MinIn[T NumberExt | StringExt, S ~[]T](s S) (T, error) {
 	if len(s) == 0 {
 		var zeroT T
 		return zeroT, ErrEmpty
@@ -43,7 +43,7 @@ func MinInPred[T any, S ~[]T](s S, lessFunc func(a, b T) bool) (T, error) {
 }
 
 // Max find the maximum value in the list
-func Max[T NumberEx | ~string](v1 T, s ...T) T {
+func Max[T NumberExt | StringExt](v1 T, s ...T) T {
 	max := v1
 	for i := range s {
 		if s[i] > max {
@@ -55,7 +55,7 @@ func Max[T NumberEx | ~string](v1 T, s ...T) T {
 
 // MaxIn finds the maximum value in the list.
 // Use max := Must(MaxIn(slice)) to panic on error.
-func MaxIn[T NumberEx | ~string, S ~[]T](s S) (T, error) {
+func MaxIn[T NumberExt | StringExt, S ~[]T](s S) (T, error) {
 	if len(s) == 0 {
 		var zeroT T
 		return zeroT, ErrEmpty
@@ -85,7 +85,7 @@ func MaxInPred[T any, S ~[]T](s S, lessFunc func(a, b T) bool) (T, error) {
 }
 
 // MinMax finds the minimum and maximum values in the list
-func MinMax[T NumberEx | ~string](v1 T, s ...T) (T, T) {
+func MinMax[T NumberExt | StringExt](v1 T, s ...T) (T, T) {
 	min := v1
 	max := v1
 	for i := range s {

--- a/number.go
+++ b/number.go
@@ -16,7 +16,7 @@ const (
 	groupSep      = ','
 )
 
-func ParseIntEx[T IntEx](s string, base int) (T, error) {
+func ParseIntEx[T IntExt](s string, base int) (T, error) {
 	var zeroT T
 	v, err := strconv.ParseInt(s, base, int(unsafe.Sizeof(zeroT)*byte2Bits))
 	if err == nil {
@@ -25,16 +25,16 @@ func ParseIntEx[T IntEx](s string, base int) (T, error) {
 	return zeroT, err // nolint: wrapcheck
 }
 
-func ParseInt[T IntEx](s string) (T, error) {
+func ParseInt[T IntExt](s string) (T, error) {
 	return ParseIntEx[T](s, base10)
 }
 
 // ParseIntUngroup omit all grouping commas then parse the string value
-func ParseIntUngroup[T IntEx](s string) (T, error) {
+func ParseIntUngroup[T IntExt](s string) (T, error) {
 	return ParseIntEx[T](NumberFmtUngroup(s, groupSep), base10)
 }
 
-func ParseIntDef[T IntEx](s string, defaultVal T) T {
+func ParseIntDef[T IntExt](s string, defaultVal T) T {
 	v, err := strconv.ParseInt(s, base10, int(unsafe.Sizeof(defaultVal)*byte2Bits))
 	if err == nil {
 		return T(v)
@@ -42,7 +42,7 @@ func ParseIntDef[T IntEx](s string, defaultVal T) T {
 	return defaultVal
 }
 
-func ParseUintEx[T UIntEx](s string, base int) (T, error) {
+func ParseUintEx[T UIntExt](s string, base int) (T, error) {
 	var zeroT T
 	v, err := strconv.ParseUint(s, base, int(unsafe.Sizeof(zeroT)*byte2Bits))
 	if err == nil {
@@ -51,16 +51,16 @@ func ParseUintEx[T UIntEx](s string, base int) (T, error) {
 	return zeroT, err // nolint: wrapcheck
 }
 
-func ParseUint[T UIntEx](s string) (T, error) {
+func ParseUint[T UIntExt](s string) (T, error) {
 	return ParseUintEx[T](s, base10)
 }
 
 // ParseUintUngroup omit all grouping commas then parse the string value
-func ParseUintUngroup[T UIntEx](s string) (T, error) {
+func ParseUintUngroup[T UIntExt](s string) (T, error) {
 	return ParseUintEx[T](NumberFmtUngroup(s, groupSep), base10)
 }
 
-func ParseUintDef[T UIntEx](s string, defaultVal T) T {
+func ParseUintDef[T UIntExt](s string, defaultVal T) T {
 	v, err := strconv.ParseUint(s, base10, int(unsafe.Sizeof(defaultVal)*byte2Bits))
 	if err == nil {
 		return T(v)
@@ -68,7 +68,7 @@ func ParseUintDef[T UIntEx](s string, defaultVal T) T {
 	return defaultVal
 }
 
-func ParseFloat[T FloatEx](s string) (T, error) {
+func ParseFloat[T FloatExt](s string) (T, error) {
 	var zeroT T
 	v, err := strconv.ParseFloat(s, int(unsafe.Sizeof(zeroT)*byte2Bits))
 	if err == nil {
@@ -78,11 +78,11 @@ func ParseFloat[T FloatEx](s string) (T, error) {
 }
 
 // ParseFloatUngroup omit all grouping commas then parse the string value
-func ParseFloatUngroup[T FloatEx](s string) (T, error) {
+func ParseFloatUngroup[T FloatExt](s string) (T, error) {
 	return ParseFloat[T](NumberFmtUngroup(s, groupSep))
 }
 
-func ParseFloatDef[T FloatEx](s string, defaultVal T) T {
+func ParseFloatDef[T FloatExt](s string, defaultVal T) T {
 	v, err := strconv.ParseFloat(s, int(unsafe.Sizeof(defaultVal)*byte2Bits))
 	if err == nil {
 		return T(v)
@@ -90,48 +90,48 @@ func ParseFloatDef[T FloatEx](s string, defaultVal T) T {
 	return defaultVal
 }
 
-func FormatIntEx[T IntEx](v T, format string) string {
+func FormatIntEx[T IntExt](v T, format string) string {
 	return fmt.Sprintf(format, v)
 }
 
-func FormatInt[T IntEx](v T) string {
+func FormatInt[T IntExt](v T) string {
 	return strconv.FormatInt(int64(v), base10)
 }
 
 // FormatIntGroup format the value then group the decimal using comma
-func FormatIntGroup[T IntEx](v T) string {
+func FormatIntGroup[T IntExt](v T) string {
 	s := strconv.FormatInt(int64(v), base10)
 	return NumberFmtGroup(s, noFractionSep, groupSep)
 }
 
-func FormatUintEx[T UIntEx](v T, format string) string {
+func FormatUintEx[T UIntExt](v T, format string) string {
 	return fmt.Sprintf(format, v)
 }
 
-func FormatUint[T UIntEx](v T) string {
+func FormatUint[T UIntExt](v T) string {
 	return strconv.FormatUint(uint64(v), base10)
 }
 
 // FormatUintGroup format the value then group the decimal using comma
-func FormatUintGroup[T UIntEx](v T) string {
+func FormatUintGroup[T UIntExt](v T) string {
 	return NumberFmtGroup(strconv.FormatUint(uint64(v), base10), noFractionSep, groupSep)
 }
 
-func FormatFloatEx[T FloatEx](v T, format string) string {
+func FormatFloatEx[T FloatExt](v T, format string) string {
 	return fmt.Sprintf(format, v)
 }
 
-func FormatFloat[T FloatEx](v T) string {
+func FormatFloat[T FloatExt](v T) string {
 	return fmt.Sprintf("%f", v)
 }
 
 // FormatFloatGroup format the value then group the decimal using comma
-func FormatFloatGroup[T FloatEx](v T) string {
+func FormatFloatGroup[T FloatExt](v T) string {
 	return NumberFmtGroup(fmt.Sprintf("%f", v), fractionSep, groupSep)
 }
 
 // FormatFloatGroupEx format the value then group the decimal using comma
-func FormatFloatGroupEx[T FloatEx](v T, format string) string {
+func FormatFloatGroupEx[T FloatExt](v T, format string) string {
 	return NumberFmtGroup(fmt.Sprintf(format, v), fractionSep, groupSep)
 }
 

--- a/product.go
+++ b/product.go
@@ -1,7 +1,7 @@
 package gofn
 
 // Product calculates product value of slice elements
-func Product[T IntEx | UIntEx | FloatEx](s ...T) T {
+func Product[T NumberExt](s ...T) T {
 	if len(s) == 0 {
 		return 0
 	}
@@ -15,7 +15,7 @@ func Product[T IntEx | UIntEx | FloatEx](s ...T) T {
 // ProductAs calculates product value with conversion to another type.
 // Type size of the result should be wider than the input's.
 // E.g. product := ProductAs[int64](int32Slice...)
-func ProductAs[U, T IntEx | UIntEx | FloatEx](s ...T) U {
+func ProductAs[U, T NumberExt](s ...T) U {
 	if len(s) == 0 {
 		return 0
 	}

--- a/slice.go
+++ b/slice.go
@@ -615,7 +615,7 @@ func SubSlice[T any, S ~[]T](s S, start, end int) S {
 
 // SliceByRange generates a slice by range.
 // start is inclusive, end is exclusive.
-func SliceByRange[T NumberEx](start, end, step T) []T {
+func SliceByRange[T NumberExt](start, end, step T) []T {
 	if end > start {
 		if step <= 0 {
 			return []T{}

--- a/sort.go
+++ b/sort.go
@@ -3,13 +3,13 @@ package gofn
 import "sort"
 
 // Sort sorts slice values
-func Sort[T NumberEx | StringEx, S ~[]T](s S) S {
+func Sort[T NumberExt | StringExt, S ~[]T](s S) S {
 	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
 	return s
 }
 
 // SortDesc sorts slice values in descending order
-func SortDesc[T NumberEx | StringEx, S ~[]T](s S) S {
+func SortDesc[T NumberExt | StringExt, S ~[]T](s S) S {
 	sort.Slice(s, func(i, j int) bool { return s[i] > s[j] })
 	return s
 }
@@ -21,13 +21,13 @@ func SortEx[T any, S ~[]T](s S, less func(i, j int) bool) S {
 }
 
 // SortStable sorts slice values
-func SortStable[T NumberEx | StringEx, S ~[]T](s S) S {
+func SortStable[T NumberExt | StringExt, S ~[]T](s S) S {
 	sort.SliceStable(s, func(i, j int) bool { return s[i] < s[j] })
 	return s
 }
 
 // SortStableDesc sorts slice values in descending order
-func SortStableDesc[T NumberEx | StringEx, S ~[]T](s S) S {
+func SortStableDesc[T NumberExt | StringExt, S ~[]T](s S) S {
 	sort.SliceStable(s, func(i, j int) bool { return s[i] > s[j] })
 	return s
 }
@@ -39,11 +39,11 @@ func SortStableEx[T any, S ~[]T](s S, less func(i, j int) bool) S {
 }
 
 // IsSorted checks if a slice is sorted
-func IsSorted[T NumberEx | StringEx, S ~[]T](s S) bool {
+func IsSorted[T NumberExt | StringExt, S ~[]T](s S) bool {
 	return sort.SliceIsSorted(s, func(i, j int) bool { return s[i] < s[j] })
 }
 
 // IsSortedDesc checks if a slice is sorted in descending order
-func IsSortedDesc[T NumberEx | StringEx, S ~[]T](s S) bool {
+func IsSortedDesc[T NumberExt | StringExt, S ~[]T](s S) bool {
 	return sort.SliceIsSorted(s, func(i, j int) bool { return s[i] > s[j] })
 }

--- a/sum.go
+++ b/sum.go
@@ -1,7 +1,7 @@
 package gofn
 
 // Sum calculates sum of slice items
-func Sum[T IntEx | UIntEx | FloatEx](s ...T) T {
+func Sum[T NumberExt](s ...T) T {
 	var sum T
 	for _, v := range s {
 		sum += v
@@ -12,7 +12,7 @@ func Sum[T IntEx | UIntEx | FloatEx](s ...T) T {
 // SumAs calculates sum value with conversion to another type.
 // Type size of the result should be wider than the input's.
 // E.g. sum := SumAs[int64](int32Slice...)
-func SumAs[U, T IntEx | UIntEx | FloatEx](s ...T) U {
+func SumAs[U, T NumberExt](s ...T) U {
 	var sum U
 	for _, v := range s {
 		sum += U(v)

--- a/types.go
+++ b/types.go
@@ -1,60 +1,79 @@
 package gofn
 
-type IntEx interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64
-}
-
 type Int interface {
 	int | int8 | int16 | int32 | int64
+}
+
+type IntExt interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
 }
 
 type IntPtr interface {
 	*int | *int8 | *int16 | *int32 | *int64
 }
 
-type UIntEx interface {
-	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
-}
-
 type UInt interface {
 	uint | uint8 | uint16 | uint32 | uint64
+}
+
+type UIntExt interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
 }
 
 type UIntPtr interface {
 	*uint | *uint8 | *uint16 | *uint32 | *uint64
 }
 
-type FloatEx interface {
-	~float32 | ~float64
-}
-
 type Float interface {
 	float32 | float64
+}
+
+type FloatExt interface {
+	~float32 | ~float64
 }
 
 type FloatPtr interface {
 	*float32 | *float64
 }
 
-type NumberEx interface {
-	IntEx | UIntEx | FloatEx
-}
-
 type Number interface {
 	Int | UInt | Float
+}
+
+type NumberExt interface {
+	IntExt | UIntExt | FloatExt
 }
 
 type NumberPtr interface {
 	IntPtr | UIntPtr | FloatPtr
 }
 
-type StringEx interface {
+type String interface {
+	string
+}
+
+type StringExt interface {
 	~string
 }
 
 type StringPtr interface {
 	*string
 }
+
+// Deprecated: Use IntExt
+type IntEx IntExt
+
+// Deprecated: Use UIntExt
+type UIntEx UIntExt
+
+// Deprecated: Use FloatExt
+type FloatEx FloatExt
+
+// Deprecated: Use NumberExt
+type NumberEx NumberExt
+
+// Deprecated: Use StringExt
+type StringEx StringExt
 
 type Tuple2[T any, U any] struct {
 	Elem1 T

--- a/util.go
+++ b/util.go
@@ -16,7 +16,7 @@ func If[C bool, T any](cond C, v1 T, v2 T) T {
 
 // Or logically selects the first value which is not zero value of type T.
 // This function is similar to `FirstTrue`, but it uses generic, not reflection.
-func Or[T NumberEx | NumberPtr | StringEx | StringPtr | ~bool | *bool](args ...T) T {
+func Or[T NumberExt | NumberPtr | StringExt | StringPtr | ~bool | *bool](args ...T) T {
 	var defaultVal T
 	for _, v := range args {
 		if v != defaultVal {


### PR DESCRIPTION
## Why

- Current type names are a bit confused. `IntEx` -> `IntExt` and so on.
- Keep old types with deprecation.