### PR TITLE
Add func `StringLexJoin/StringLexJoinEx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,17 @@ s := StringJoinBy([]Struct{{I:1, s:"a"}, {I:2, s:"b"}}, ", ", func (v Struct) st
 }) // s == "1:a, 2:b"
 ```
 
+#### StringLexJoin / StringLexJoinEx
+
+Joins a slice of any element type in lexical manner.
+
+```go
+StringLexJoin([]int{1,2,3}, ", ", " and ")              // return "1, 2 and 3"
+
+// Use a custom format string
+StringLexJoinEx([]int64{254, 255}, ", ", " or ", "%#x") // returns "0xfe or 0xff"
+```
+
 #### MultilineString
 
 Removes all leading spaces from every line in the given string. This function is useful to declare a string with a neat multiline-style.

--- a/string_test.go
+++ b/string_test.go
@@ -49,6 +49,17 @@ func Test_StringJoinPred_Deprecated(t *testing.T) {
 	}))
 }
 
+func Test_StringLexJoin(t *testing.T) {
+	assert.Equal(t, "", StringLexJoin([]int{}, ", ", " and "))
+	assert.Equal(t, "123", StringLexJoin([]int32{123}, ", ", " and "))
+	assert.Equal(t, "1 or 2", StringLexJoin([]int64{1, 2}, ", ", " or "))
+	assert.Equal(t, "1, null and 3", StringLexJoin([]any{1, nil, "3"}, ", ", " and "))
+	assert.Equal(t, "1, null, true and finally 3",
+		StringLexJoin([]any{1, nil, true, "3"}, ", ", " and finally "))
+
+	assert.Equal(t, "0xfe or 0xff", StringLexJoinEx([]int64{254, 255}, ", ", " or ", "%#x"))
+}
+
 func Test_LinesTrimLeft(t *testing.T) {
 	assert.Equal(t, "", LinesTrimLeftSpace(""))
 	assert.Equal(t, "line-1\nline-2", LinesTrimLeftSpace(`line-1


### PR DESCRIPTION
## What

- Add func `StringLexJoin/StringLexJoinEx`
- Use strings.Builder in existing functions `StringJoinBy` for better performance