### PR TITLE
Refactor: rename func GetFirst / GetLast

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ go get github.com/tiendc/gofn
   - [Concat](#concat)
   - [Fill](#fill)
   - [SliceByRange](#slicebyrange)
-  - [GetFirst](#getfirst)
-  - [GetLast](#getlast)
+  - [First / FirstOr](#first--firstor)
+  - [Last / LastOr](#last--lastor)
 
 **Slice searching**
   - [Contain](#contain--containby)
@@ -302,28 +302,30 @@ s2 := s[2:4]
 Fill(s2, 1) // s2 == []int{1, 1}, s == []int{0, 0, 1, 1, 0}
 ```
 
-#### GetFirst
+#### First / FirstOr
 
-Returns the first element of slice if it is not empty, otherwise return the default value.
+Returns the first element of slice.
 
 ```go
-GetFirst([]int{1, 2, 3}, 4) // 1
-GetFirst([]int{}, 11)       // 11
+First([]int{1, 2, 3})      // 1, true
+First([]string{})          // "", false
 
-HeadOf([]int{1, 2, 3})      // 1, true
-HeadOf([]string{})          // "", false
+// Return the default value if slice is empty
+FirstOr([]int{1, 2, 3}, 4) // 1
+FirstOr([]int{}, 11)       // 11
 ```
 
-#### GetLast
+#### Last / LastOr
 
-Returns the last element of slice if it is not empty, otherwise return the default value.
+Returns the last element of slice.
 
 ```go
-GetLast([]int{1, 2, 3}, 4)  // 3
-GetLast([]int{}, 11)        // 11
+Last([]int{1, 2, 3})       // 3, true
+Last([]string{})           // "", false
 
-TailOf([]int{1, 2, 3})      // 3, true
-TailOf([]string{})          // "", false
+// Return the default value if slice is empty
+LastOr([]int{1, 2, 3}, 4)  // 3
+LastOr([]int{}, 11)        // 11
 ```
 
 #### SliceByRange

--- a/slice.go
+++ b/slice.go
@@ -527,27 +527,23 @@ func CountValuePred[T any, S ~[]T](a S, pred func(t T) bool) int {
 	return CountValueBy(a, pred)
 }
 
-// GetFirst gets the first item in slice.
+// FirstOr gets the first item in slice.
 // Returns the default value if slice is empty.
-func GetFirst[T any, S ~[]T](s S, defaultVal T) T {
+func FirstOr[T any, S ~[]T](s S, defaultVal T) T {
 	if len(s) > 0 {
 		return s[0]
 	}
 	return defaultVal
 }
 
-// GetLast gets the last item in slice.
-// Returns the default value if slice is empty.
-func GetLast[T any, S ~[]T](s S, defaultVal T) T {
-	if len(s) > 0 {
-		return s[len(s)-1]
-	}
-	return defaultVal
+// Deprecated: use FirstOr instead
+func GetFirst[T any, S ~[]T](s S, defaultVal T) T {
+	return FirstOr(s, defaultVal)
 }
 
-// HeadOf returns the first item in slice.
+// First returns the first item in slice.
 // Returns zero value and `false` if the slice is empty.
-func HeadOf[T any, S ~[]T](s S) (T, bool) {
+func First[T any, S ~[]T](s S) (T, bool) {
 	if len(s) > 0 {
 		return s[0], true
 	}
@@ -555,9 +551,23 @@ func HeadOf[T any, S ~[]T](s S) (T, bool) {
 	return zero, false
 }
 
-// TailOf returns the last item in slice.
+// LastOr gets the last item in slice.
+// Returns the default value if slice is empty.
+func LastOr[T any, S ~[]T](s S, defaultVal T) T {
+	if len(s) > 0 {
+		return s[len(s)-1]
+	}
+	return defaultVal
+}
+
+// Deprecated: use LastOr instead
+func GetLast[T any, S ~[]T](s S, defaultVal T) T {
+	return LastOr(s, defaultVal)
+}
+
+// Last returns the last item in slice.
 // Returns zero value and `false` if the slice is empty.
-func TailOf[T any, S ~[]T](s S) (T, bool) {
+func Last[T any, S ~[]T](s S) (T, bool) {
 	if len(s) > 0 {
 		return s[len(s)-1], true
 	}

--- a/slice_test.go
+++ b/slice_test.go
@@ -1004,31 +1004,41 @@ func Test_CountValuePred_Deprecated(t *testing.T) {
 		func(t any) bool { return t == 1.1 }))
 }
 
-func Test_GetFirst(t *testing.T) {
+func Test_FirstOr(t *testing.T) {
+	assert.Equal(t, 1, FirstOr([]int{1, 2, 3}, 4))
+	assert.Equal(t, 11, FirstOr([]int{}, 11))
+}
+
+func Test_GetFirst_Deprecated(t *testing.T) {
 	assert.Equal(t, 1, GetFirst([]int{1, 2, 3}, 4))
 	assert.Equal(t, 11, GetFirst([]int{}, 11))
 }
 
-func Test_GetLast(t *testing.T) {
+func Test_HeadOf(t *testing.T) {
+	v1, f := First([]string{})
+	assert.True(t, v1 == "" && !f)
+	v2, f := First([]int(nil))
+	assert.True(t, v2 == 0 && !f)
+	v3, f := First([]int{1, 2, 3})
+	assert.True(t, v3 == 1 && f)
+}
+
+func Test_LastOr(t *testing.T) {
+	assert.Equal(t, 3, LastOr([]int{1, 2, 3}, 4))
+	assert.Equal(t, 11, LastOr([]int{}, 11))
+}
+
+func Test_GetLast_Deprecated(t *testing.T) {
 	assert.Equal(t, 3, GetLast([]int{1, 2, 3}, 4))
 	assert.Equal(t, 11, GetLast([]int{}, 11))
 }
 
-func Test_HeadOf(t *testing.T) {
-	v1, f := HeadOf([]string{})
+func Test_Last(t *testing.T) {
+	v1, f := Last([]string{})
 	assert.True(t, v1 == "" && !f)
-	v2, f := HeadOf([]int(nil))
+	v2, f := Last([]int(nil))
 	assert.True(t, v2 == 0 && !f)
-	v3, f := HeadOf([]int{1, 2, 3})
-	assert.True(t, v3 == 1 && f)
-}
-
-func Test_TailOf(t *testing.T) {
-	v1, f := TailOf([]string{})
-	assert.True(t, v1 == "" && !f)
-	v2, f := TailOf([]int(nil))
-	assert.True(t, v2 == 0 && !f)
-	v3, f := TailOf([]int{1, 2, 3})
+	v3, f := Last([]int{1, 2, 3})
 	assert.True(t, v3 == 3 && f)
 }
 


### PR DESCRIPTION
## What

- Renamed GetFirst -> FirstOr (deprecate GetFirst)
- Renamed GetLast -> LastOr (deprecate GetLast)
- Renamed HeadOf -> First (no deprecation)
- Renamed TailOf -> Last (no deprecation)