### PR TITLE
Rename `ReduceRight` to `ReduceReverse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ go get github.com/tiendc/gofn
   - [Intersection / IntersectionBy](#intersection--intersectionby)
   - [Difference / DifferenceBy](#difference--differenceby)
   - [Reduce / ReduceEx](#reduce--reduceex)
-  - [ReduceRight / ReduceRightEx](#reduceright--reducerightex)
+  - [ReduceReverse / ReduceReverseEx](#reducereverse--reducereverseex)
   - [Partition / PartitionN](#partition--partitionn)
   - [Flatten / Flatten3](#flatten--flatten3)
   - [Zip / Zip\<N\>](#zip--zipn)
@@ -640,16 +640,16 @@ ReduceEx([]int{1, 2, 3}, func (accumulator int, currentValue int, i index) int {
 }, 10) // 16
 ```
 
-#### ReduceRight / ReduceRightEx
+#### ReduceReverse / ReduceReverseEx
 
 Reduces a slice to a value with iterating from the end.
 
 ```go
-ReduceRight([]int{1, 2, 3}, func (accumulator int, currentValue int) int {
+ReduceReverse([]int{1, 2, 3}, func (accumulator int, currentValue int) int {
     return accumulator + currentValue
 }) // 6
 
-ReduceRightEx([]int{1, 2, 3}, func (accumulator int, currentValue int, i index) int {
+ReduceReverseEx([]int{1, 2, 3}, func (accumulator int, currentValue int, i index) int {
     return accumulator + currentValue
 }, 10) // 16
 ```

--- a/slice_algo.go
+++ b/slice_algo.go
@@ -116,8 +116,8 @@ func ReduceEx[T any, U any, S ~[]T](
 	return accumulator
 }
 
-// ReduceRight reduces a slice to a value
-func ReduceRight[T any, S ~[]T](s S, reduceFunc func(accumulator, currentValue T) T) T {
+// ReduceReverse reduces a slice to a value
+func ReduceReverse[T any, S ~[]T](s S, reduceFunc func(accumulator, currentValue T) T) T {
 	length := len(s)
 	if length == 0 {
 		var zeroT T
@@ -130,8 +130,8 @@ func ReduceRight[T any, S ~[]T](s S, reduceFunc func(accumulator, currentValue T
 	return accumulator
 }
 
-// ReduceRightEx reduces a slice to a value with custom initial value
-func ReduceRightEx[T any, U any, S ~[]T](
+// ReduceReverseEx reduces a slice to a value with custom initial value
+func ReduceReverseEx[T any, U any, S ~[]T](
 	s S,
 	reduceFunc func(accumulator U, currentValue T, currentIndex int) U,
 	initVal U,

--- a/slice_algo_test.go
+++ b/slice_algo_test.go
@@ -127,21 +127,21 @@ func Test_ReduceEx(t *testing.T) {
 	assert.Equal(t, 0, ReduceEx[int]([]int{1, 2, 0}, func(acc, v, i int) int { return acc * v }, 1))
 }
 
-func Test_ReduceRight(t *testing.T) {
+func Test_ReduceReverse(t *testing.T) {
 	// Empty slice
-	assert.Equal(t, 0, ReduceRight[int]([]int{}, func(acc, v int) int { return acc + v }))
+	assert.Equal(t, 0, ReduceReverse[int]([]int{}, func(acc, v int) int { return acc + v }))
 	// Slice has 1 element
-	assert.Equal(t, 1, ReduceRight[int]([]int{1}, func(acc, v int) int { return acc + v }))
+	assert.Equal(t, 1, ReduceReverse[int]([]int{1}, func(acc, v int) int { return acc + v }))
 
-	assert.Equal(t, 6, ReduceRight[int]([]int{1, 2, 3}, func(acc, v int) int { return acc + v }))
-	assert.Equal(t, 8, ReduceRight[int]([]int{1, 2, 4}, func(acc, v int) int { return acc * v }))
-	assert.Equal(t, 0, ReduceRight[int]([]int{1, 2, 0}, func(acc, v int) int { return acc * v }))
+	assert.Equal(t, 6, ReduceReverse[int]([]int{1, 2, 3}, func(acc, v int) int { return acc + v }))
+	assert.Equal(t, 8, ReduceReverse[int]([]int{1, 2, 4}, func(acc, v int) int { return acc * v }))
+	assert.Equal(t, 0, ReduceReverse[int]([]int{1, 2, 0}, func(acc, v int) int { return acc * v }))
 }
 
-func Test_ReduceRightEx(t *testing.T) {
-	assert.Equal(t, 7, ReduceRightEx[int]([]int{1, 2, 3}, func(acc, v, i int) int { return acc + v }, 1))
-	assert.Equal(t, 8, ReduceRightEx[int]([]int{1, 2, 4}, func(acc, v, i int) int { return acc * v }, 1))
-	assert.Equal(t, 0, ReduceRightEx[int]([]int{1, 2, 0}, func(acc, v, i int) int { return acc * v }, 1))
+func Test_ReduceReverseEx(t *testing.T) {
+	assert.Equal(t, 7, ReduceReverseEx[int]([]int{1, 2, 3}, func(acc, v, i int) int { return acc + v }, 1))
+	assert.Equal(t, 8, ReduceReverseEx[int]([]int{1, 2, 4}, func(acc, v, i int) int { return acc * v }, 1))
+	assert.Equal(t, 0, ReduceReverseEx[int]([]int{1, 2, 0}, func(acc, v, i int) int { return acc * v }, 1))
 }
 
 func Test_Partition(t *testing.T) {


### PR DESCRIPTION
## Why

- Use of `Right` suffix is not consistent with our current naming convention.