### PR TITLE
Refactor: deprecate `FirstTrue`, `Or`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ go get github.com/tiendc/gofn
   - [RandChoiceMaker](#randchoicemaker)
 
 **Utility**
-  - [FirstTrue](#firsttrue)
-  - [Or](#or)
+  - [FirstNonEmpty](#firstnonempty)
+  - [Coalesce](#coalesce)
   - [If](#if)
   - [Must\<N\>](#mustn)
   - [ToPtr](#toptr)
@@ -1289,33 +1289,34 @@ ProductAs[int]([]int8{5, 6, 7}) // 210 (Product() will fail as the result overfl
 ### Utility
 ---
 
-#### FirstTrue
+#### FirstNonEmpty
 
-Returns the first "true" value in the given arguments if found.
-Values considered "true" are:
+Returns the first non-zero value in the given arguments if found, otherwise returns the zero value.
+This function use `reflection`. Consider using `Coalesce` for generic types.
+
+Values considered "non-zero" are:
   - not zero values (0, empty string, false, nil, ...)
   - not empty containers (slice, array, map, channel)
   - not pointers that point to zero/empty values
 
 ```go
-FirstTrue(0, 0, -1, 2, 3)                       // -1
-FirstTrue("", "", " ", "b")                     // " "
-FirstTrue([]int{}, nil, []int{1}, []int{2, 3})  // []int{1}
-FirstTrue([]int{}, nil, &[]int{}, []int{2, 3})  // []int{2, 3}
-FirstTrue[any](nil, 0, 0.0, "", struct{}{})     // nil (the first zero value)
+FirstNonEmpty(0, -1, 2, 3)                          // -1
+FirstNonEmpty("", " ", "b")                         // " "
+FirstNonEmpty([]int{}, nil, []int{1}, []int{2, 3})  // []int{1}
+FirstNonEmpty([]int{}, nil, &[]int{}, []int{2, 3})  // []int{2, 3}
+FirstNonEmpty[any](nil, 0, 0.0, "", struct{}{})     // nil (the first zero value)
 ```
 
-#### Or
+#### Coalesce
 
-Logically selects the first value which is not zero value of type T.
-This function is similar to `FirstTrue`, but it uses generic, not reflection, and it accepts primitive types only.
+Returns the first non-zero argument. Input type must be comparable.
 
 ```go
-Or(0, -1, 2)         // -1
-Or("", " ", "s")     // " "
-Or[*int](ptr1, ptr2) // the first non-nil pointer
+Coalesce(0, -1, 2)         // -1
+Coalesce("", " ", "s")     // " "
+Coalesce[*int](ptr1, ptr2) // the first non-nil pointer
 ```
- 
+
 #### If
 
 A convenient function works like C ternary operator.

--- a/util_test.go
+++ b/util_test.go
@@ -14,40 +14,15 @@ func Test_If(t *testing.T) {
 	assert.Equal(t, "b", If(x > y, "a", "b"))
 }
 
-func Test_Or(t *testing.T) {
-	// Primitive types
-	assert.Equal(t, false, Or(false, false))
-	assert.Equal(t, true, Or(false, true, false))
-	assert.Equal(t, 1, Or(1))
-	assert.Equal(t, 1, Or(1, 0, 2))
-	assert.Equal(t, -1.5, Or[float64](0, -1.5))
-	assert.Equal(t, float32(0), Or[float32](0, 0.0, 0))
-	assert.Equal(t, int64(-2), Or[int64](0, 0, -2, 0))
-	assert.Equal(t, byte(1), Or[byte](1, 0, 2, 0))
-	assert.Equal(t, "", Or("", ""))
-	assert.Equal(t, "f", Or("", "f", ""))
-
-	// Pointer to primitive types
-	assert.Equal(t, (*int)(nil), Or[*int](nil, nil))
-	f1, f2 := float32(0), float32(1)
-	assert.Equal(t, &f1, Or(nil, &f1, &f2, nil))
-	s1, s2 := "", "1"
-	assert.Equal(t, &s1, Or(nil, &s1, &s2, nil))
-
-	// Derived type
-	type X string
-	assert.Equal(t, X("f"), Or[X]("", "f", "g"))
-}
-
-func Test_FirstTrue(t *testing.T) {
-	assert.Equal(t, -1, FirstTrue(0, 0, -1, 2, 3))
-	assert.Equal(t, "a", FirstTrue("", "", "a", "b"))
-	assert.Equal(t, " ", FirstTrue("", "", " ", "b"))
-	assert.Equal(t, []int{1}, FirstTrue([]int{}, []int{}, nil, []int{1}, []int{2, 3}))
-	assert.Equal(t, map[int]int{1: 1}, FirstTrue(map[int]int{}, nil, map[int]int{1: 1}, map[int]int{2: 2}))
-	assert.Nil(t, FirstTrue[*int](nil, nil, nil))
+func Test_FirstNonEmpty(t *testing.T) {
+	assert.Equal(t, -1, FirstNonEmpty(0, 0, -1, 2, 3))
+	assert.Equal(t, "a", FirstNonEmpty("", "", "a", "b"))
+	assert.Equal(t, " ", FirstNonEmpty("", "", " ", "b"))
+	assert.Equal(t, []int{1}, FirstNonEmpty([]int{}, []int{}, nil, []int{1}, []int{2, 3}))
+	assert.Equal(t, map[int]int{1: 1}, FirstNonEmpty(map[int]int{}, nil, map[int]int{1: 1}, map[int]int{2: 2}))
+	assert.Nil(t, FirstNonEmpty[*int](nil, nil, nil))
 	int1, int2 := 1, 2
-	assert.Equal(t, &int2, FirstTrue[*int](nil, nil, &int2, &int1))
+	assert.Equal(t, &int2, FirstNonEmpty[*int](nil, nil, &int2, &int1))
 
 	type Str string
 	type A struct {
@@ -63,8 +38,55 @@ func Test_FirstTrue(t *testing.T) {
 	dt := time.Time{}
 	cp := complex(0, 0)
 	var iface any
-	assert.Equal(t, []int{1}, FirstTrue[any](false, "", 0, 0.0, cp, Str(""), A{}, B{}, struct{}{},
+	assert.Equal(t, []int{1}, FirstNonEmpty[any](false, "", 0, 0.0, cp, Str(""), A{}, B{}, struct{}{},
 		nil, ch, dt, iface, &[]int{}, []string{}, map[int]int{}, []int{1}, "x"))
+}
+
+func Test_FirstTrue_Deprecated(t *testing.T) {
+	assert.Equal(t, -1, FirstNonEmpty(0, 0, -1, 2, 3))
+	assert.Equal(t, "a", FirstNonEmpty("", "", "a", "b"))
+	assert.Equal(t, " ", FirstNonEmpty("", "", " ", "b"))
+	assert.Equal(t, []int{1}, FirstNonEmpty([]int{}, []int{}, nil, []int{1}, []int{2, 3}))
+	assert.Equal(t, map[int]int{1: 1}, FirstNonEmpty(map[int]int{}, nil, map[int]int{1: 1}, map[int]int{2: 2}))
+	assert.Nil(t, FirstNonEmpty[*int](nil, nil, nil))
+}
+
+func Test_Coalesce(t *testing.T) {
+	// Primitive types
+	assert.Equal(t, false, Coalesce(false, false))
+	assert.Equal(t, true, Coalesce(false, true, false))
+	assert.Equal(t, 1, Coalesce(1))
+	assert.Equal(t, 1, Coalesce(1, 0, 2))
+	assert.Equal(t, -1.5, Coalesce[float64](0, -1.5))
+	assert.Equal(t, float32(0), Coalesce[float32](0, 0.0, 0))
+	assert.Equal(t, int64(-2), Coalesce[int64](0, 0, -2, 0))
+	assert.Equal(t, byte(1), Coalesce[byte](1, 0, 2, 0))
+	assert.Equal(t, "", Coalesce("", ""))
+	assert.Equal(t, "f", Coalesce("", "f", ""))
+
+	// Pointer to primitive types
+	assert.Equal(t, (*int)(nil), Or[*int](nil, nil))
+	f1, f2 := float32(0), float32(1)
+	assert.Equal(t, &f1, Or(nil, &f1, &f2, nil))
+	s1, s2 := "", "1"
+	assert.Equal(t, &s1, Or(nil, &s1, &s2, nil))
+
+	// Derived type
+	type X string
+	assert.Equal(t, X("f"), Or[X]("", "f", "g"))
+}
+
+func Test_Or_Deprecated(t *testing.T) {
+	assert.Equal(t, false, Or(false, false))
+	assert.Equal(t, true, Or(false, true, false))
+	assert.Equal(t, 1, Or(1))
+	assert.Equal(t, 1, Or(1, 0, 2))
+	assert.Equal(t, -1.5, Or[float64](0, -1.5))
+	assert.Equal(t, float32(0), Or[float32](0, 0.0, 0))
+	assert.Equal(t, int64(-2), Or[int64](0, 0, -2, 0))
+	assert.Equal(t, byte(1), Or[byte](1, 0, 2, 0))
+	assert.Equal(t, "", Or("", ""))
+	assert.Equal(t, "f", Or("", "f", ""))
 }
 
 // nolint: goerr113, forcetypeassert


### PR DESCRIPTION
## What

- Rename `FirstTrue` -> `FirstNonEmpty`, deprecate `FirstTrue`
- Rename `Or` -> `Coalesce`, deprecate `Or`