### PR TITLE
Fix/Rename `stringIsNumeric`

### DIFF
--- a/number.go
+++ b/number.go
@@ -165,7 +165,7 @@ func NumberFmtUngroup(num string, groupSep byte) string {
 }
 
 func numberPartFmtGroup(s string, groupSep byte) string {
-	if groupSep == 0 || !stringIsNumeric(s, true) {
+	if groupSep == 0 || !stringIsInteger(s, true) {
 		return s
 	}
 	buf := make([]byte, 0, len(s)+5) //nolint:mnd
@@ -189,8 +189,15 @@ func numberPartFmtGroup(s string, groupSep byte) string {
 	return string(buf)
 }
 
-func stringIsNumeric(s string, allowSign bool) bool {
-	if allowSign && len(s) > 0 && s[0] == '-' {
+func stringIsInteger(s string, allowSign bool) bool {
+	length := len(s)
+	if length == 0 {
+		return false
+	}
+	if s[0] == '-' {
+		if !allowSign || length == 1 {
+			return false
+		}
 		s = s[1:]
 	}
 	for _, ch := range s {

--- a/number_test.go
+++ b/number_test.go
@@ -347,3 +347,15 @@ func Test_NumberGroups(t *testing.T) {
 		assert.Equal(t, tc.ungroup, NumberFmtUngroup(tc.grouped, groupSep), fmt.Sprintf("ungroup #%d", i))
 	}
 }
+
+func Test_stringIsInteger(t *testing.T) {
+	assert.False(t, stringIsInteger("", true))
+	assert.False(t, stringIsInteger("-", true))
+	assert.False(t, stringIsInteger("-123", false))
+	assert.False(t, stringIsInteger("1.23", false))
+	assert.False(t, stringIsInteger("1e3", false))
+
+	assert.True(t, stringIsInteger("123", true))
+	assert.True(t, stringIsInteger("123", false))
+	assert.True(t, stringIsInteger("-123", true))
+}


### PR DESCRIPTION
## What

- This func only checks integer, renamed it to `stringIsInteger`
- Fix bug within it